### PR TITLE
Allow me to get to the last page of results

### DIFF
--- a/src/routes/languages/[slug].svelte
+++ b/src/routes/languages/[slug].svelte
@@ -61,7 +61,7 @@
   let offset = page * pageSize;
 
   $: pages = Math.ceil(response.count / pageSize)-1;
-  $: morePages = page+1 < pages;
+  $: morePages = page+1 <= pages;
 
   async function next() {
     page++;


### PR DESCRIPTION
Related to #3 - I think we need this as well as your other fix in order to get to the last page of results, otherwise the "Next" button is disabled.

**Before:**
<img width="819" alt="image" src="https://user-images.githubusercontent.com/6248612/109015855-2e03fb80-767b-11eb-8944-530ba699b5ba.png">


**After:**
<img width="819" alt="image" src="https://user-images.githubusercontent.com/6248612/109015878-32301900-767b-11eb-84ee-63868e81ba9e.png">
